### PR TITLE
Add SQLite datasource and schema initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # JDBCrew
+
+## Lokale Entwicklung
+
+### Datenbank initialisieren
+
+Die Spring-Boot-Anwendung im Modul `device-bridge` nutzt eine lokale SQLite-Datenbank (`data.db`).
+Führe den folgenden Befehl im Modulverzeichnis aus, um die Datenbank und das Schema anzulegen:
+
+```bash
+cd device-bridge
+mvn spring-boot:run
+```
+
+Beim Start liest Spring Boot die Datei `src/main/resources/schema.sql` und legt dadurch die benötigten
+Tabellen an (z. B. `items`). Nachdem der Server erfolgreich gestartet ist, kannst du ihn mit `Strg+C`
+beenden; die initialisierte `data.db` bleibt erhalten.
+
+### Anwendung testen
+
+Nach der Initialisierung kannst du denselben Befehl erneut verwenden, um die Anwendung zu starten
+und lokal zu testen:
+
+```bash
+cd device-bridge
+mvn spring-boot:run
+```
+
+Die Anwendung läuft dann standardmäßig auf `http://localhost:8080` und greift auf die eben
+initialisierte SQLite-Datenbank zu.

--- a/device-bridge/src/main/resources/application.yml
+++ b/device-bridge/src/main/resources/application.yml
@@ -11,3 +11,11 @@ devices:
 spring:
   jackson:
     default-property-inclusion: non_null
+  datasource:
+    url: jdbc:sqlite:./data.db
+    driver-class-name: org.sqlite.JDBC
+    username:
+    password:
+  sql:
+    init:
+      mode: always

--- a/device-bridge/src/main/resources/schema.sql
+++ b/device-bridge/src/main/resources/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS items(
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);


### PR DESCRIPTION
## Summary
- rename the Spring configuration to `application.yml`
- configure a local SQLite datasource with SQL initialization
- add a default schema and document database setup in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c89ba393288331a48c20080c2d04b9