### PR TITLE
Add schema inspection endpoint and UI

### DIFF
--- a/device-bridge/src/main/java/de/jdbcrew/devicebridge/controller/DbController.java
+++ b/device-bridge/src/main/java/de/jdbcrew/devicebridge/controller/DbController.java
@@ -83,6 +83,12 @@ public class DbController {
         return ResponseEntity.ok(dbService.fetchItems(db, nameFilter));
     }
 
+    @GetMapping("/schema")
+    public ResponseEntity<List<Map<String, Object>>> schema(@PathVariable String db) {
+        ensureSupported(db);
+        return ResponseEntity.ok(dbService.fetchSchema());
+    }
+
     private void ensureSupported(String db) {
         if (!dbService.isSupportedDb(db)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Unbekannte Datenbank: " + db);

--- a/device-bridge/src/main/resources/static/index.html
+++ b/device-bridge/src/main/resources/static/index.html
@@ -106,6 +106,15 @@
         <table id="dataTable" class="table"></table>
       </div>
     </section>
+
+    <!-- SCHEMA VIEW -->
+    <section class="card" style="grid-column: 1 / -1;">
+      <h2>6) Schema anzeigen</h2>
+      <div class="actions">
+        <button id="btnLoadSchema">Schema laden</button>
+      </div>
+      <pre id="schemaOutput" class="code-block">Noch nicht geladen.</pre>
+    </section>
   </div>
 
   <footer>

--- a/device-bridge/src/main/resources/static/styles.css
+++ b/device-bridge/src/main/resources/static/styles.css
@@ -138,6 +138,21 @@ header {
   text-align: left;
 }
 
+.code-block {
+  background: #0b1220;
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 12px;
+  max-height: 50vh;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* =========================================
    6) Form Controls & Buttons
 ========================================= */


### PR DESCRIPTION
## Summary
- add a database service method and REST endpoint to expose the SQLite schema
- extend the single-page frontend to request the schema and render it in a new card
- style the schema output to display table definitions and columns in a readable way

## Testing
- mvn test *(fails: Maven Central unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a371e858833192f01a0c172a0554