### PR TITLE
Add device services and dynamic target resolution

### DIFF
--- a/device-bridge/src/main/java/de/jdbcrew/devicebridge/service/AwsDeviceService.java
+++ b/device-bridge/src/main/java/de/jdbcrew/devicebridge/service/AwsDeviceService.java
@@ -1,0 +1,73 @@
+package de.jdbcrew.devicebridge.service;
+
+import de.jdbcrew.devicebridge.dto.StatusResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Service
+public class AwsDeviceService implements DeviceService {
+
+    private final String baseUrl;
+    private final RestClient client;
+    private final boolean mock;
+
+    public AwsDeviceService(
+            @Value("${devices.aws.base-url:}") String baseUrl,
+            RestClient.Builder builder
+    ) {
+        this.baseUrl = baseUrl == null ? "" : baseUrl.trim();
+        this.mock = this.baseUrl.isEmpty();
+        this.client = builder.build();
+    }
+
+    @Override
+    public String getTarget() {
+        return "aws";
+    }
+
+    @Override
+    public StatusResponse getStatus() {
+        if (mock) {
+            return StatusResponse.ok(getTarget(), Map.of(
+                    "region", "eu-central-1",
+                    "instances", 3,
+                    "status", "healthy"
+            ));
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = client.get()
+                    .uri(baseUrl + "/api/status")
+                    .retrieve()
+                    .body(Map.class);
+            return StatusResponse.ok(getTarget(), data);
+        } catch (Exception e) {
+            return StatusResponse.error(getTarget(), "AWS unreachable: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public StatusResponse runCommand(String command) {
+        if (mock) {
+            return StatusResponse.ok(getTarget(), Map.of(
+                    "stdout", "(mock aws) ran: " + command
+            ));
+        }
+        try {
+            Map<String, Object> payload = Map.of("command", command);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = client.post()
+                    .uri(baseUrl + "/api/command")
+                    .body(payload)
+                    .retrieve()
+                    .body(Map.class);
+            return StatusResponse.ok(getTarget(), data);
+        } catch (Exception e) {
+            return StatusResponse.error(getTarget(), "AWS command failed: " + e.getMessage());
+        }
+    }
+}
+

--- a/device-bridge/src/main/java/de/jdbcrew/devicebridge/service/ServerDeviceService.java
+++ b/device-bridge/src/main/java/de/jdbcrew/devicebridge/service/ServerDeviceService.java
@@ -1,0 +1,74 @@
+package de.jdbcrew.devicebridge.service;
+
+import de.jdbcrew.devicebridge.dto.StatusResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ServerDeviceService implements DeviceService {
+
+    private final String baseUrl;
+    private final RestClient client;
+    private final boolean mock;
+
+    public ServerDeviceService(
+            @Value("${devices.server.base-url:}") String baseUrl,
+            RestClient.Builder builder
+    ) {
+        this.baseUrl = baseUrl == null ? "" : baseUrl.trim();
+        this.mock = this.baseUrl.isEmpty();
+        this.client = builder.build();
+    }
+
+    @Override
+    public String getTarget() {
+        return "server";
+    }
+
+    @Override
+    public StatusResponse getStatus() {
+        if (mock) {
+            return StatusResponse.ok(getTarget(), Map.of(
+                    "uptime", "12:34:56",
+                    "services", List.of("api", "db"),
+                    "load", 0.42
+            ));
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = client.get()
+                    .uri(baseUrl + "/api/status")
+                    .retrieve()
+                    .body(Map.class);
+            return StatusResponse.ok(getTarget(), data);
+        } catch (Exception e) {
+            return StatusResponse.error(getTarget(), "Server unreachable: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public StatusResponse runCommand(String command) {
+        if (mock) {
+            return StatusResponse.ok(getTarget(), Map.of(
+                    "stdout", "(mock server) ran: " + command
+            ));
+        }
+        try {
+            Map<String, Object> payload = Map.of("command", command);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> data = client.post()
+                    .uri(baseUrl + "/api/command")
+                    .body(payload)
+                    .retrieve()
+                    .body(Map.class);
+            return StatusResponse.ok(getTarget(), data);
+        } catch (Exception e) {
+            return StatusResponse.error(getTarget(), "Server command failed: " + e.getMessage());
+        }
+    }
+}
+

--- a/device-bridge/src/main/resources/application.yml
+++ b/device-bridge/src/main/resources/application.yml
@@ -7,6 +7,8 @@ devices:
     base-url: ""     # z.B. http://raspberrypi.local:8081 (später eintragen)
   server:
     base-url: ""     # z.B. http://server.local:8081
+  aws:
+    base-url: ""     # z.B. https://api.aws.example.com
 
 spring:
   jackson:

--- a/device-bridge/src/test/java/de/jdbcrew/devicebridge/controller/DeviceControllerTest.java
+++ b/device-bridge/src/test/java/de/jdbcrew/devicebridge/controller/DeviceControllerTest.java
@@ -1,0 +1,67 @@
+package de.jdbcrew.devicebridge.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DeviceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void returnsStatusForAllKnownTargets() throws Exception {
+        mockMvc.perform(get("/api/devices/pi/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.target").value("pi"))
+                .andExpect(jsonPath("$.reachable").value(true));
+
+        mockMvc.perform(get("/api/devices/server/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.target").value("server"))
+                .andExpect(jsonPath("$.reachable").value(true));
+
+        mockMvc.perform(get("/api/devices/aws/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.target").value("aws"))
+                .andExpect(jsonPath("$.reachable").value(true));
+    }
+
+    @Test
+    void runsCommandsForDifferentTargets() throws Exception {
+        String payload = "{\"command\":\"echo hi\"}";
+
+        mockMvc.perform(post("/api/devices/server/command")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.target").value("server"))
+                .andExpect(jsonPath("$.reachable").value(true))
+                .andExpect(jsonPath("$.data.stdout").value("(mock server) ran: echo hi"));
+
+        mockMvc.perform(post("/api/devices/aws/command")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.target").value("aws"))
+                .andExpect(jsonPath("$.reachable").value(true))
+                .andExpect(jsonPath("$.data.stdout").value("(mock aws) ran: echo hi"));
+    }
+
+    @Test
+    void rejectsUnknownTarget() throws Exception {
+        mockMvc.perform(get("/api/devices/unknown/status"))
+                .andExpect(status().isBadRequest());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated AWS and server device services with mock fallbacks for offline mode
- update the device controller to resolve device services dynamically by target
- extend configuration for new device base URLs and add tests covering multi-target resolution

## Testing
- mvn test *(fails: unable to download parent POM because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c946e63bb883208ec83a72d2488620